### PR TITLE
Discarding the master and slave phrasing

### DIFF
--- a/jmeterd/jmeter/migrations/0001_initial.py
+++ b/jmeterd/jmeter/migrations/0001_initial.py
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
                 ('ip', models.GenericIPAddressField(default='127.0.0.1', verbose_name='IP地址')),
                 ('password', models.CharField(default='', max_length=50, verbose_name='password')),
                 ('status', models.BooleanField(default=0, verbose_name='状态, 离线/在线')),
-                ('is_slave', models.BooleanField(default=False, verbose_name='是否是从机器, 只允许一个主机器')),
+                ('is_subordinate', models.BooleanField(default=False, verbose_name='是否是从机器, 只允许一个主机器')),
                 ('gmt_create', models.DateTimeField(auto_now_add=True, verbose_name='创建时间')),
                 ('gmt_modified', models.DateTimeField(auto_now=True, verbose_name='修改时间')),
             ],

--- a/jmeterd/jmeter/models.py
+++ b/jmeterd/jmeter/models.py
@@ -276,7 +276,7 @@ class Machine(models.Model):
 
     )
 
-    is_slave = models.BooleanField(
+    is_subordinate = models.BooleanField(
         '是否是从机器, 只允许一个主机器',
         blank=False,
         null=False,

--- a/jmeterd/jmeter/serializers.py
+++ b/jmeterd/jmeter/serializers.py
@@ -15,7 +15,7 @@ class MachineSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Machine
-        fields = ('name', 'port', 'ip', 'password', 'status', 'is_slave', 'task')
+        fields = ('name', 'port', 'ip', 'password', 'status', 'is_subordinate', 'task')
 
 class TaskSerializer(serializers.ModelSerializer):
     """

--- a/jmeterd/jmeter/service/just_run.py
+++ b/jmeterd/jmeter/service/just_run.py
@@ -15,7 +15,7 @@ class TaskRun():
         self.task_id = task_id
         machines = Machines()
         self.task = self._task
-        self.machine_connection = MachineConnection(machines.master_machine)
+        self.machine_connection = MachineConnection(machines.main_machine)
 
 
         self.jmeter_executor = JmeterExecutor(

--- a/jmeterd/jmeter/service/machine_connection.py
+++ b/jmeterd/jmeter/service/machine_connection.py
@@ -45,8 +45,8 @@ class MachineConfig():
 class Machines():
 
     def __init__(self):
-        self.master_machine = None
-        self.slave_machines = []
+        self.main_machine = None
+        self.subordinate_machines = []
         self._make_machines()
 
     def _make_machines(self):
@@ -57,10 +57,10 @@ class Machines():
         machines = Machine.objects.all()
 
         for machine in machines:
-            if machine.is_slave is False:
-                self.master_machine = machine
+            if machine.is_subordinate is False:
+                self.main_machine = machine
             else:
-                self.slave_machines.append(machine)
+                self.subordinate_machines.append(machine)
 
     def update_status(self):
         """


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.